### PR TITLE
The libasound library has a very different name in redhat

### DIFF
--- a/README
+++ b/README
@@ -14,6 +14,10 @@ for that installed. In Debian or Ubuntu, you can install it by running:
 
 	apt-get install libasound2-dev
 
+In Fedora, Centos, or Redhat:
+
+	yum install alsa-lib-devel
+
 After you compile ttyMIDI, you may wish to copy it to /usr/bin for easy
 access. This can be done simply by following command:
 

--- a/src/ttymidi.c
+++ b/src/ttymidi.c
@@ -481,7 +481,7 @@ void* read_midi_from_serial_port(void* seq)
 /* --------------------------------------------------------------------- */
 // Main program
 
-main(int argc, char** argv)
+int main(int argc, char** argv)
 {
 	//arguments arguments;
 	struct termios oldtio, newtio;


### PR DESCRIPTION
Also my compiler griped about main() not having an int, so I patched that up.

One final request: I originally got this code from http://www.varal.org/ttymidi/ through a serpentine series of links on the internet for noobs trying to do midi things with arduinos. It seems that the code there is from 8 years ago instead of the 6 year old code with the gcc -lpthread patch in the Makefile. If you've access to that website, it might be good to update it or make it a link to the github zip file of the master branch.

Anyways, thanks for making this gizmo. Letting me compile it is saving my life since the rest of them seem to all want me to have 32 bit libraries installed.